### PR TITLE
Fix parsing for space-separated whitelist patterns

### DIFF
--- a/bin/usb-wakeup-blocker.sh
+++ b/bin/usb-wakeup-blocker.sh
@@ -266,7 +266,10 @@ main() {
       if declare -p WHITELIST_PATTERNS 2>/dev/null | grep -q '^declare \-a '; then
         WL_PATTERNS+=("${WHITELIST_PATTERNS[@]}")
       else
+        local OLDIFS=$IFS
+        IFS=$' \t\n'
         read -r -a _tmp <<<"$WHITELIST_PATTERNS"
+        IFS=$OLDIFS
         WL_PATTERNS+=("${_tmp[@]}")
         unset _tmp
       fi
@@ -276,7 +279,10 @@ main() {
       if declare -p whitelist_patterns 2>/dev/null | grep -q '^declare \-a '; then
         WL_PATTERNS+=("${whitelist_patterns[@]}")
       else
+        local OLDIFS=$IFS
+        IFS=$' \t\n'
         read -r -a _tmp2 <<<"$whitelist_patterns"
+        IFS=$OLDIFS
         WL_PATTERNS+=("${_tmp2[@]}")
         unset _tmp2
       fi

--- a/test/test.bats
+++ b/test/test.bats
@@ -101,6 +101,31 @@ EOF
     assert_equal "$(cat "$MOCK_SYS_PATH/usb4/power/wakeup")" "enabled"
 }
 
+@test "Config WHITELIST_PATTERNS handles space-separated values" {
+    # reset
+    echo enabled > "$MOCK_SYS_PATH/usb1/power/wakeup"
+    echo enabled > "$MOCK_SYS_PATH/usb2/power/wakeup"
+    echo enabled > "$MOCK_SYS_PATH/usb3/power/wakeup"
+    echo enabled > "$MOCK_SYS_PATH/usb4/power/wakeup"
+
+    config_file="$BATS_TMPDIR/uwb.conf"
+    cat > "$config_file" <<'EOF'
+MODE=combo
+WHITELIST_PATTERNS='Mouse Device Keyboard Device'
+EOF
+    export CONFIG_FILE="$config_file"
+
+    run "$TEST_SCRIPT_PATH"
+    assert_success
+
+    assert_equal "$(cat "$MOCK_SYS_PATH/usb1/power/wakeup")" "enabled"  # Whitelisted
+    assert_equal "$(cat "$MOCK_SYS_PATH/usb2/power/wakeup")" "enabled"  # Whitelisted
+    assert_equal "$(cat "$MOCK_SYS_PATH/usb3/power/wakeup")" "disabled"
+    assert_equal "$(cat "$MOCK_SYS_PATH/usb4/power/wakeup")" "enabled"
+
+    unset CONFIG_FILE
+}
+
 @test "Dry run (-d): should not change any files" {
     # reset
     echo enabled > "$MOCK_SYS_PATH/usb1/power/wakeup"


### PR DESCRIPTION
## Summary
- ensure config `WHITELIST_PATTERNS` splits space-separated items correctly by temporarily restoring IFS
- add regression test for parsing space-separated whitelist patterns

## Testing
- `./test/run-tests.sh` *(fails: unable to clone bats-core submodules, CONNECT tunnel failed 403)*
- `shellcheck bin/usb-wakeup-blocker.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd67f133c83279534f48c592024d6