### PR TITLE
feat: support quoted whitelist patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ sudo /usr/local/bin/usb-wakeup-blocker.sh -v
 ```
 
 
+### Direct script configuration
+
+The same file may define variables consumed by the script itself. Quote
+multi-word whitelist patterns so they remain intact when parsed:
+
+```ini
+MODE=combo
+WHITELIST_PATTERNS='"Mouse Device" "Keyboard Device"'
+```
+
+Each entry is matched against the device's `Product` name.
+
 Restart the service to apply:
 ```bash
 sudo systemctl restart usb-wakeup-blocker.service

--- a/bin/usb-wakeup-blocker.sh
+++ b/bin/usb-wakeup-blocker.sh
@@ -266,12 +266,8 @@ main() {
       if declare -p WHITELIST_PATTERNS 2>/dev/null | grep -q '^declare \-a '; then
         WL_PATTERNS+=("${WHITELIST_PATTERNS[@]}")
       else
-        local OLDIFS=$IFS
-        IFS=$' \t\n'
-        read -r -a _tmp <<<"$WHITELIST_PATTERNS"
-        IFS=$OLDIFS
-        WL_PATTERNS+=("${_tmp[@]}")
-        unset _tmp
+        # Use eval to honour quoted multi-word entries
+        eval "WL_PATTERNS+=($WHITELIST_PATTERNS)"
       fi
     fi
     # Also accept lowercase key, if present
@@ -279,12 +275,7 @@ main() {
       if declare -p whitelist_patterns 2>/dev/null | grep -q '^declare \-a '; then
         WL_PATTERNS+=("${whitelist_patterns[@]}")
       else
-        local OLDIFS=$IFS
-        IFS=$' \t\n'
-        read -r -a _tmp2 <<<"$whitelist_patterns"
-        IFS=$OLDIFS
-        WL_PATTERNS+=("${_tmp2[@]}")
-        unset _tmp2
+        eval "WL_PATTERNS+=($whitelist_patterns)"
       fi
     fi
   fi

--- a/test/test.bats
+++ b/test/test.bats
@@ -111,7 +111,7 @@ EOF
     config_file="$BATS_TMPDIR/uwb.conf"
     cat > "$config_file" <<'EOF'
 MODE=combo
-WHITELIST_PATTERNS='Mouse Device Keyboard Device'
+WHITELIST_PATTERNS='"Mouse Device" "Keyboard Device"'
 EOF
     export CONFIG_FILE="$config_file"
 


### PR DESCRIPTION
## Summary
- support quoted multi-word patterns in `WHITELIST_PATTERNS`
- document quoting syntax for whitelist patterns
- adjust tests for new config parsing

## Testing
- `./test/run-tests.sh` *(fails: unable to clone bats submodules)*
- `shellcheck bin/usb-wakeup-blocker.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddb621f1c8327b1daf7e6b9df89ed