### PR TITLE
Clarify -a blocking example in config

### DIFF
--- a/etc/usb-wakeup-blocker.conf
+++ b/etc/usb-wakeup-blocker.conf
@@ -21,7 +21,7 @@
 # Allow a specific external keyboard to wake the system:
 # ARGS='-c -w "My Awesome Keyboard"'
 #
-# Allow a keyboard and mouse to wake the system:
+# Use -a to block all devices except the whitelisted keyboard and mouse:
 # ARGS='-a -w "My Awesome Keyboard" -w "USB Receiver"'
 #
 # By default, no devices are whitelisted.


### PR DESCRIPTION
## Summary
- Clarify that using `-a` blocks all devices except the specified keyboard and mouse

## Testing
- `./test/run-tests.sh` *(failed: CONNECT tunnel failed, response 403 while cloning submodules)*

------
https://chatgpt.com/codex/tasks/task_e_689de24f27748327b902a234d3999385