### PR TITLE
feat: use conditional sudo in install and uninstall scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -ne 0 ]]; then SUDO=sudo; else SUDO=; fi
+
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "Usage: sudo $0"
     echo "Installs the usb-wakeup-blocker script and systemd service."
@@ -25,16 +27,16 @@ for f in "$SOURCE_BIN" "$SOURCE_CONFIG" "$SOURCE_SERVICE"; do
     fi
 done
 
-sudo install -Dm755 "$SOURCE_BIN" "$BIN"
-sudo install -d "$CONFIG_DIR"
+${SUDO} install -Dm755 "$SOURCE_BIN" "$BIN"
+${SUDO} install -d "$CONFIG_DIR"
 # Install config file only if it doesn't exist to preserve user changes.
 # Using a test condition for better portability instead of the non-standard -n flag.
 if [ ! -f "$CONFIG_FILE" ]; then
-    sudo install -m644 "$SOURCE_CONFIG" "$CONFIG_FILE"
+    ${SUDO} install -m644 "$SOURCE_CONFIG" "$CONFIG_FILE"
 fi
-sudo install -Dm644 "$SOURCE_SERVICE" "$SERVICE"
+${SUDO} install -Dm644 "$SOURCE_SERVICE" "$SERVICE"
 
-sudo systemctl daemon-reload
+${SUDO} systemctl daemon-reload
 
 echo "Installed successfully."
 echo "Configuration file template created at '/etc/usb-wakeup-blocker.conf'."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
+if [[ $EUID -ne 0 ]]; then SUDO=sudo; else SUDO=; fi
 set -euo pipefail
 
 BIN="/usr/local/bin/usb-wakeup-blocker.sh"
 SERVICE="/etc/systemd/system/usb-wakeup-blocker.service"
 CONFIG_FILE="/etc/usb-wakeup-blocker.conf"
 
-sudo systemctl disable --now usb-wakeup-blocker.service || true
-sudo rm -f "$SERVICE"
-sudo systemctl daemon-reload
+${SUDO} systemctl disable --now usb-wakeup-blocker.service || true
+${SUDO} rm -f "$SERVICE"
+${SUDO} systemctl daemon-reload
 
-sudo rm -f "$BIN"
-sudo rm -f "$CONFIG_FILE"
+${SUDO} rm -f "$BIN"
+${SUDO} rm -f "$CONFIG_FILE"
 
 echo "Uninstalled."
 echo "A reboot is recommended to fully revert changes to wakeup settings."


### PR DESCRIPTION
## Summary
- Define a `SUDO` variable in install/uninstall scripts that uses `sudo` when not run as root
- Replace hardcoded `sudo` calls with `${SUDO}` to support both root and non-root execution

## Testing
- `bash -x install.sh --help`
- `su nobody -s /bin/bash -c 'bash -x install.sh --help'`
- `./test/run-tests.sh` *(fails: fatal: unable to access 'https://github.com/bats-core/bats-assert.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689de747ced883278006279416188991