### PR TITLE
Add help option to uninstall script and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ sudo systemctl restart usb-wakeup-blocker.service
 sudo ./uninstall.sh
 ```
 
+Run `./uninstall.sh --help` to see available options.
+
 Removes:
 - Installed script
 - systemd service file

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    cat <<'EOF'
+usb-wakeup-blocker uninstall script
+
+Usage: ./uninstall.sh [--help|-h]
+
+Removes installed usb-wakeup-blocker service, script, and configuration file.
+Requires root privileges (sudo is used if not run as root).
+EOF
+    exit 0
+fi
 if [[ $EUID -ne 0 ]]; then SUDO=sudo; else SUDO=; fi
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- support `--help`/`-h` in `uninstall.sh` to display usage and description
- document the new help flag in the README's Uninstallation section

## Testing
- `./test/run-tests.sh` *(fails: CONNECT tunnel failed, response 403)*
- `shellcheck uninstall.sh` *(fails: shellcheck not found and package install blocked: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689de82536788327b749d172b521edb0