### PR TITLE
docs: document prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ By default:
 
 ---
 
+## Prerequisites
+
+This project targets Linux systems that use **systemd** and requires the `usbutils` package so that `lsusb` is available. If `usbutils` isn't installed, add it, for example on Debian/Ubuntu:
+
+```bash
+sudo apt install usbutils
+```
+
+---
+
 ## Quick Start (default: block only mice)
 
 ```bash


### PR DESCRIPTION
## Summary
- document system requirements including usbutils and systemd

## Testing
- `./test/run-tests.sh` *(fails: unable to clone submodules, CONNECT tunnel failed 403)*
- `shellcheck bin/usb-wakeup-blocker.sh` *(fails: command not found; apt repositories 403 when attempting installation)*

------
https://chatgpt.com/codex/tasks/task_e_689deaf799fc832780c57a8dc636ad3b