### PR TITLE
docs: split configuration section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ The configuration file is located at:
 /etc/usb-wakeup-blocker.conf
 ```
 
-Edit the `ARGS` variable to pass options to the script when started by systemd.
+### Service Arguments (systemd)
+
+Use the `ARGS` variable to pass command-line options to the script when it is
+started by systemd. This controls which USB devices are blocked.
 
 **Example: Block both mice and keyboards, but whitelist a specific keyboard**
 ```ini
@@ -93,11 +96,11 @@ You can find device names by running:
 sudo /usr/local/bin/usb-wakeup-blocker.sh -v
 ```
 
+### Script Variables
 
-### Direct script configuration
-
-The same file may define variables consumed by the script itself. Quote
-multi-word whitelist patterns so they remain intact when parsed:
+These variables are read directly by the script to set its default behaviour.
+Use them to define the mode and whitelist patterns. Quote multi-word whitelist
+patterns so they remain intact when parsed:
 
 ```ini
 MODE=combo


### PR DESCRIPTION
## Summary
- split README configuration section into distinct service arguments and script variables subsections
- clarify usage and relocate examples for ARGS, MODE, and WHITELIST_PATTERNS

## Testing
- `./test/run-tests.sh` *(fails: unable to clone submodules, 403 Forbidden)*
- `shellcheck bin/usb-wakeup-blocker.sh` *(fails: shellcheck not installed and apt-get update 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689decde89b083279d80c7ed187f3d6d