### PR TITLE
docs: add dry-run example for whitelist verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ You can find device names by running:
 sudo /usr/local/bin/usb-wakeup-blocker.sh -v
 ```
 
+To verify a product name before adding it to the configuration file, run a dry
+run with the desired whitelist pattern:
+
+```bash
+sudo /usr/local/bin/usb-wakeup-blocker.sh -d -w "My USB Keyboard"
+```
+
+The `-d` flag performs a trial run without modifying system settings, letting
+you confirm that the device is interpreted correctly.
+
 ### Script Variables
 
 These variables are read directly by the script to set its default behaviour.


### PR DESCRIPTION
## Summary
- document how to use `-d` with `-w` to test product names

## Testing
- `./test/run-tests.sh` *(fails: unable to clone bats submodules, 403 Forbidden)*
- `shellcheck bin/usb-wakeup-blocker.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dee5b51108327950c42acd82776d3